### PR TITLE
[DRR] Suport Tensor Assgin API in ResultPattern

### DIFF
--- a/paddle/fluid/ir/drr/drr_rewrite_pattern.h
+++ b/paddle/fluid/ir/drr/drr_rewrite_pattern.h
@@ -250,11 +250,14 @@ class DrrRewritePattern : public ir::OpRewritePattern<SourceOp> {
     MatchContextImpl res_match_ctx = CreateOperations(
         *result_pattern_graph_, source_pattern_match_ctx, rewriter);
 
-    // 2. Replace Output Values in source_pattern_graph by Output Values in
+    // 2. Process Assign Tensor
+    RebindIrTensorForAssignTensor(*result_pattern_graph_, &res_match_ctx);
+
+    // 3. Replace Output Values in source_pattern_graph by Output Values in
     // result_pattern_graph
     ReplaceOutputTensor(source_pattern_match_ctx, res_match_ctx, rewriter);
 
-    // 3. Delete Operations in source_pattern_graph
+    // 4. Delete Operations in source_pattern_graph
     DeleteSourcePatternOp(
         *source_pattern_graph_, source_pattern_match_ctx, rewriter);
   }
@@ -280,6 +283,20 @@ class DrrRewritePattern : public ir::OpRewritePattern<SourceOp> {
         });
 
     return res_match_ctx;
+  }
+
+  void RebindIrTensorForAssignTensor(
+      const ResultPatternGraph& result_pattern_graph,
+      MatchContextImpl* res_match_ctx) const {
+    const auto& tensor_assign_map = result_pattern_graph.tensor_assign_map();
+    for (const auto& kv : tensor_assign_map) {
+      const auto& src_tensor_name = kv.first;
+      const auto& dst_tensor_name = kv.second;
+      res_match_ctx->BindIrValue(
+          src_tensor_name,
+          std::make_shared<IrValue>(
+              res_match_ctx->GetIrValue(dst_tensor_name)));
+    }
   }
 
   void ReplaceOutputTensor(const MatchContextImpl& src_match_ctx,

--- a/paddle/fluid/ir/drr/pattern_graph.cc
+++ b/paddle/fluid/ir/drr/pattern_graph.cc
@@ -46,7 +46,7 @@ const drr::OpCall &PatternGraph::AddOpCall(
   return *owned_op_call_.back();
 }
 
-const drr::Tensor &PatternGraph::AddTensor(
+drr::Tensor &PatternGraph::AddTensor(
     const std::shared_ptr<drr::Tensor> &tensor) {
   if (id2owned_tensor_.find(tensor->name()) == id2owned_tensor_.end()) {
     id2owned_tensor_[tensor->name()] = tensor;
@@ -122,6 +122,18 @@ void PatternGraph::Print() const {
 
 const OpCall *SourcePatternGraph::AnchorNode() const {
   return id2owned_tensor_.at(*output_tensors_.begin())->producer();
+}
+
+void ResultPatternGraph::AssignTensor(const Tensor &from, const Tensor &to) {
+  if (to.producer() == nullptr) {
+    input_tensors_.insert(to.name());
+  }
+  output_tensors_.erase(to.name());
+  IR_ENFORCE(output_tensors_.count(from.name()) == 1,
+             "The Tensor (%s) which be assigned must be the output of result "
+             "pattern graph.",
+             from.name());
+  tensor_assign_map_[from.name()] = to.name();
 }
 
 void GraphTopo::WalkGraphNodesTopoOrder(

--- a/paddle/fluid/ir/drr/pattern_graph.h
+++ b/paddle/fluid/ir/drr/pattern_graph.h
@@ -31,9 +31,11 @@ class Tensor;
 
 class PatternGraph {
  public:
+  virtual ~PatternGraph() {}
+
   const drr::OpCall& AddOpCall(const std::shared_ptr<drr::OpCall>& op_call);
 
-  const drr::Tensor& AddTensor(const std::shared_ptr<drr::Tensor>& tensor);
+  drr::Tensor& AddTensor(const std::shared_ptr<drr::Tensor>& tensor);
 
   drr::Tensor& AddTmpTensor(const std::shared_ptr<drr::Tensor>& tensor);
 
@@ -76,7 +78,18 @@ class SourcePatternGraph : public PatternGraph {
   friend class DrrPatternContext;
 };
 
-class ResultPatternGraph : public PatternGraph {};
+class ResultPatternGraph : public PatternGraph {
+ public:
+  void AssignTensor(const Tensor& from, const Tensor& to);
+
+  const std::unordered_map<std::string, std::string>& tensor_assign_map()
+      const {
+    return tensor_assign_map_;
+  }
+
+ private:
+  std::unordered_map<std::string, std::string> tensor_assign_map_;
+};
 
 class GraphTopo {
  public:

--- a/test/cpp/ir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/ir/pattern_rewrite/drr_test.cc
@@ -125,10 +125,6 @@ struct RemoveRedundentCastFunctor {
         pat.Op("pd.cast", {{"dtype", pat.Attr("dtype1")}})(pat.Tensor("arg0"));
     pat.Tensor("ret") =
         pat.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(pat.Tensor("tmp"));
-    pat.RequireNativeCall([](const ir::drr::MatchContext &match_ctx) -> bool {
-      return match_ctx.Tensor("ret").Dtype() ==
-             match_ctx.Tensor("arg0").Dtype();
-    });
     auto res = pat.ResultPattern();
     res.Tensor("ret") =
         res.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(res.Tensor("arg0"));
@@ -142,6 +138,25 @@ class RemoveRedundentCastPattern
   using ir::drr::DrrRewritePattern<
       paddle::dialect::CastOp,
       RemoveRedundentCastFunctor>::DrrRewritePattern;
+};
+
+struct RemoveUselessCastFunctor {
+  void operator()(ir::drr::DrrPatternContext *ctx) {
+    auto pat = ctx->SourcePattern();
+    pat.Tensor("ret") =
+        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(pat.Tensor("arg0"));
+    pat.RequireEqual(pat.Tensor("ret").dtype(), pat.Tensor("arg0").dtype());
+    auto res = pat.ResultPattern();
+    res.Tensor("ret").Assign(res.Tensor("arg0"));
+  }
+};
+
+class RemoveUselessCastPattern
+    : public ir::drr::DrrRewritePattern<paddle::dialect::CastOp,
+                                        RemoveUselessCastFunctor> {
+ public:
+  using ir::drr::DrrRewritePattern<paddle::dialect::CastOp,
+                                   RemoveUselessCastFunctor>::DrrRewritePattern;
 };
 
 void BuildProgram(ir::Builder &builder) {  // NOLINT
@@ -191,6 +206,7 @@ class DrrPatternRewritePass : public ir::Pass {
     ps.Add(std::make_unique<RemoveRedundentReshapePattern>(context));
     ps.Add(std::make_unique<RemoveRedundentTransposePattern>(context));
     ps.Add(std::make_unique<RemoveRedundentCastPattern>(context));
+    ps.Add(std::make_unique<RemoveUselessCastPattern>(context));
 
     patterns_ = ir::FrozenRewritePatternSet(std::move(ps));
     return true;
@@ -227,5 +243,5 @@ TEST(DrrTest, drr) {
   pm.EnableIRPrinting();
 
   CHECK_EQ(pm.Run(&program), true);
-  EXPECT_EQ(program.block()->size(), 8u);
+  EXPECT_EQ(program.block()->size(), 7u);
 }

--- a/test/cpp/ir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/ir/pattern_rewrite/drr_test.cc
@@ -143,8 +143,7 @@ class RemoveRedundentCastPattern
 struct RemoveUselessCastFunctor {
   void operator()(ir::drr::DrrPatternContext *ctx) {
     auto pat = ctx->SourcePattern();
-    pat.Tensor("ret") =
-        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(pat.Tensor("arg0"));
+    pat.Tensor("ret") = pat.Op("pd.cast")(pat.Tensor("arg0"));
     pat.RequireEqual(pat.Tensor("ret").dtype(), pat.Tensor("arg0").dtype());
     auto res = pat.ResultPattern();
     res.Tensor("ret").Assign(res.Tensor("arg0"));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what you’ve done -->
DRR API 支持在ResultPattern中对Tensor使用Assgin操作。

使用示例：
```
  auto pat = ctx->SourcePattern();
  pat.Tensor("ret") = pat.Op("pd.cast")(pat.Tensor("arg0"));
  pat.RequireEqual(pat.Tensor("ret").dtype(), pat.Tensor("arg0").dtype());
  auto res = pat.ResultPattern();
  res.Tensor("ret").Assign(res.Tensor("arg0"));
```
