### PR TITLE
[DRR] Refactor ther drr pattern class

### DIFF
--- a/paddle/fluid/ir/drr/api/drr_pattern_base.h
+++ b/paddle/fluid/ir/drr/api/drr_pattern_base.h
@@ -20,7 +20,7 @@
 namespace ir {
 namespace drr {
 
-class DrrPatternBuilder {
+class DrrPatternBase {
  public:
   // Define the Drr Pattern.
   virtual void operator()(ir::drr::DrrPatternContext* ctx) const = 0;

--- a/paddle/fluid/ir/drr/api/drr_pattern_builder.h
+++ b/paddle/fluid/ir/drr/api/drr_pattern_builder.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/ir/drr/api/drr_pattern_context.h"
+#include "paddle/fluid/ir/drr/drr_rewrite_pattern.h"
+
+namespace ir {
+namespace drr {
+
+class DrrPatternBuilder {
+ public:
+  // Define the Drr Pattern.
+  virtual void operator()(ir::drr::DrrPatternContext* ctx) const = 0;
+
+  std::unique_ptr<DrrRewritePattern> Build(
+      ir::IrContext* ir_context, ir::PatternBenefit benefit = 1) const {
+    DrrPatternContext drr_context;
+    this->operator()(&drr_context);
+    return std::make_unique<DrrRewritePattern>(
+        drr_context, ir_context, benefit);
+  }
+};
+
+}  // namespace drr
+}  // namespace ir

--- a/test/cpp/ir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/ir/pattern_rewrite/drr_test.cc
@@ -18,13 +18,13 @@
 
 #include "paddle/fluid/ir/dialect/pd_dialect.h"
 #include "paddle/fluid/ir/dialect/pd_op.h"
-#include "paddle/fluid/ir/drr/api/drr_pattern_builder.h"
+#include "paddle/fluid/ir/drr/api/drr_pattern_base.h"
 #include "paddle/ir/pass/pass.h"
 #include "paddle/ir/pass/pass_manager.h"
 #include "paddle/ir/pattern_rewrite/pattern_rewrite_driver.h"
 #include "paddle/ir/transforms/dead_code_elimination_pass.h"
 
-class RemoveRedundentReshapePattern : public ir::drr::DrrPatternBuilder {
+class RemoveRedundentReshapePattern : public ir::drr::DrrPatternBase {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     // Source patterns：待匹配的子图
@@ -44,7 +44,7 @@ class RemoveRedundentReshapePattern : public ir::drr::DrrPatternBuilder {
   }
 };
 
-class FoldBroadcastToConstantPattern : public ir::drr::DrrPatternBuilder {
+class FoldBroadcastToConstantPattern : public ir::drr::DrrPatternBase {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     ir::drr::SourcePattern pat = ctx->SourcePattern();
@@ -71,7 +71,7 @@ class FoldBroadcastToConstantPattern : public ir::drr::DrrPatternBuilder {
   }
 };
 
-class RemoveRedundentTransposePattern : public ir::drr::DrrPatternBuilder {
+class RemoveRedundentTransposePattern : public ir::drr::DrrPatternBase {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     // Source pattern: 待匹配的子图
@@ -93,7 +93,7 @@ class RemoveRedundentTransposePattern : public ir::drr::DrrPatternBuilder {
   }
 };
 
-class RemoveRedundentCastPattern : public ir::drr::DrrPatternBuilder {
+class RemoveRedundentCastPattern : public ir::drr::DrrPatternBase {
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     auto pat = ctx->SourcePattern();
     pat.Tensor("tmp") =
@@ -106,7 +106,7 @@ class RemoveRedundentCastPattern : public ir::drr::DrrPatternBuilder {
   }
 };
 
-class RemoveUselessCastPattern : public ir::drr::DrrPatternBuilder {
+class RemoveUselessCastPattern : public ir::drr::DrrPatternBase {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     auto pat = ctx->SourcePattern();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
对DRR的用户实现接口类进行了简化重构：
 
1. 将原先定义2次class减少为了1次
2. 用户无需再手动指定作为比对起始节点的SourceOp

修改后的 DRR Pattern 开发代码如下：

重构后：
```
class RemoveRedundentCast : public ir::drr::DrrPatternBuilder {
  void operator()(ir::drr::DrrPatternContext *ctx) const override {
    auto pat = ctx->SourcePattern();
    pat.Tensor("tmp") =
        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype1")}})(pat.Tensor("arg0"));
    pat.Tensor("ret") =
        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(pat.Tensor("tmp"))
    auto res = pat.ResultPattern();
    res.Tensor("ret") =
        res.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(res.Tensor("arg0"));
  }
};
```

重构前：
```
struct RemoveRedundentCastFunctor {
  void operator()(ir::drr::DrrPatternContext *ctx) {
    auto pat = ctx->SourcePattern();
    pat.Tensor("tmp") =
        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype1")}})(pat.Tensor("arg0"));
    pat.Tensor("ret") =
        pat.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(pat.Tensor("tmp"));
    auto res = pat.ResultPattern();
    res.Tensor("ret") =
        res.Op("pd.cast", {{"dtype", pat.Attr("dtype2")}})(res.Tensor("arg0"));
  }
};

class RemoveRedundentCastPattern
    : public ir::drr::DrrRewritePattern<paddle::dialect::CastOp,
                                        RemoveRedundentCastFunctor> {
 public:
  using ir::drr::DrrRewritePattern<
      paddle::dialect::CastOp,
      RemoveRedundentCastFunctor>::DrrRewritePattern;
};
```
