### PR TITLE
[DRR] Support compute attribute in drr pattern

### DIFF
--- a/paddle/fluid/ir/drr/api/drr_pattern_base.h
+++ b/paddle/fluid/ir/drr/api/drr_pattern_base.h
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <typeinfo>
-
 #include "paddle/fluid/ir/drr/api/drr_pattern_context.h"
 #include "paddle/fluid/ir/drr/drr_rewrite_pattern.h"
+#include "paddle/ir/core/type_name.h"
 
 namespace ir {
 namespace drr {
 
+template <typename DrrPattern>
 class DrrPatternBase {
  public:
   virtual ~DrrPatternBase() = default;
@@ -34,7 +34,7 @@ class DrrPatternBase {
     DrrPatternContext drr_context;
     this->operator()(&drr_context);
     return std::make_unique<DrrRewritePattern>(
-        typeid(*this).name(), drr_context, ir_context, benefit);
+        ir::get_type_name<DrrPattern>(), drr_context, ir_context, benefit);
   }
 };
 

--- a/paddle/fluid/ir/drr/api/drr_pattern_context.h
+++ b/paddle/fluid/ir/drr/api/drr_pattern_context.h
@@ -46,19 +46,19 @@ class NormalAttribute {
   std::string attr_name_;
 };
 
+using AttrComputeFunc = std::function<std::any(const MatchContext&)>;
+
 class ComputeAttribute {
  public:
-  explicit ComputeAttribute(
-      const std::function<std::any(const MatchContext&)>& attr_compute_func)
+  explicit ComputeAttribute(const AttrComputeFunc& attr_compute_func)
       : attr_compute_func_(attr_compute_func) {}
 
-  const std::function<std::any(const MatchContext&)>& attr_compute_func()
-      const {
+  const AttrComputeFunc& attr_compute_func() const {
     return attr_compute_func_;
   }
 
  private:
-  std::function<std::any(const MatchContext&)> attr_compute_func_;
+  AttrComputeFunc attr_compute_func_;
 };
 
 using Attribute = std::variant<NormalAttribute, ComputeAttribute>;
@@ -267,8 +267,7 @@ class ResultPattern {
   Attribute Attr(const std::string& attr_name) const {
     return NormalAttribute(attr_name);
   }
-  Attribute Attr(
-      std::function<std::any(const MatchContext&)> attr_compute_func) const {
+  Attribute Attr(const AttrComputeFunc& attr_compute_func) const {
     return ComputeAttribute(attr_compute_func);
   }
 

--- a/test/cpp/ir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/ir/pattern_rewrite/drr_test.cc
@@ -24,7 +24,8 @@
 #include "paddle/ir/pattern_rewrite/pattern_rewrite_driver.h"
 #include "paddle/ir/transforms/dead_code_elimination_pass.h"
 
-class RemoveRedundentReshapePattern : public ir::drr::DrrPatternBase {
+class RemoveRedundentReshapePattern
+    : public ir::drr::DrrPatternBase<RemoveRedundentReshapePattern> {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     // Source patterns：待匹配的子图
@@ -44,7 +45,8 @@ class RemoveRedundentReshapePattern : public ir::drr::DrrPatternBase {
   }
 };
 
-class FoldBroadcastToConstantPattern : public ir::drr::DrrPatternBase {
+class FoldBroadcastToConstantPattern
+    : public ir::drr::DrrPatternBase<FoldBroadcastToConstantPattern> {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     ir::drr::SourcePattern pat = ctx->SourcePattern();
@@ -71,7 +73,8 @@ class FoldBroadcastToConstantPattern : public ir::drr::DrrPatternBase {
   }
 };
 
-class RemoveRedundentTransposePattern : public ir::drr::DrrPatternBase {
+class RemoveRedundentTransposePattern
+    : public ir::drr::DrrPatternBase<RemoveRedundentTransposePattern> {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     // Source pattern: 待匹配的子图
@@ -93,7 +96,8 @@ class RemoveRedundentTransposePattern : public ir::drr::DrrPatternBase {
   }
 };
 
-class RemoveRedundentCastPattern : public ir::drr::DrrPatternBase {
+class RemoveRedundentCastPattern
+    : public ir::drr::DrrPatternBase<RemoveRedundentCastPattern> {
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     auto pat = ctx->SourcePattern();
     pat.Tensor("tmp") =
@@ -106,7 +110,8 @@ class RemoveRedundentCastPattern : public ir::drr::DrrPatternBase {
   }
 };
 
-class RemoveUselessCastPattern : public ir::drr::DrrPatternBase {
+class RemoveUselessCastPattern
+    : public ir::drr::DrrPatternBase<RemoveUselessCastPattern> {
  public:
   void operator()(ir::drr::DrrPatternContext *ctx) const override {
     auto pat = ctx->SourcePattern();

--- a/test/cpp/ir/pattern_rewrite/drr_test.cc
+++ b/test/cpp/ir/pattern_rewrite/drr_test.cc
@@ -88,9 +88,18 @@ class RemoveRedundentTransposePattern
 
     // Result patterns: 要替换的子图
     ir::drr::ResultPattern res = pat.ResultPattern();
-    // todo 先简单用perm2替换
+    const auto &new_perm_attr =
+        res.Attr([](const ir::drr::MatchContext &match_ctx) -> std::any {
+          const auto &perm1 = match_ctx.Attr<std::vector<int>>("perm_1");
+          const auto &perm2 = match_ctx.Attr<std::vector<int>>("perm_2");
+          std::vector<int> new_perm;
+          for (int v : perm2) {
+            new_perm.emplace_back(perm1[v]);
+          }
+          return new_perm;
+        });
     const auto &tranpose_continuous =
-        res.Op("pd.transpose", {{"perm", pat.Attr("perm_2")}});
+        res.Op("pd.transpose", {{"perm", new_perm_attr}});
 
     res.Tensor("ret") = tranpose_continuous(res.Tensor("arg_transpose"));
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
支持在DRR Pattern中进行Attribute的计算处理，使用示例如下：
```
ir::drr::ResultPattern res = pat.ResultPattern();
    const auto &new_perm_attr =
        res.Attr([](const ir::drr::MatchContext &match_ctx) -> std::any {
          const auto &perm1 = match_ctx.Attr<std::vector<int>>("perm_1");
          const auto &perm2 = match_ctx.Attr<std::vector<int>>("perm_2");
          std::vector<int> new_perm;
          for (int v : perm2) {
            new_perm.emplace_back(perm1[v]);
          }
          return new_perm;
        });
    const auto &tranpose_continuous =
        res.Op("pd.transpose", {{"perm", new_perm_attr}});

    res.Tensor("ret") = tranpose_continuous(res.Tensor("arg_transpose"));
```