### PR TITLE
Add fusion testing code for fullOp and expandOp

### DIFF
--- a/paddle/fluid/ir/drr/ir_operation_creator.cc
+++ b/paddle/fluid/ir/drr/ir_operation_creator.cc
@@ -70,6 +70,7 @@ Operation* CreateOperation(const OpCall& op_call,
         op_call.outputs()[1]->name(),
         std::make_shared<IrValue>(reshape_op->result(1)));
     return reshape_op;
+    
   } else if (op_call.name() == "pd.transpose") {
     const auto& inputs = op_call.inputs();
     std::vector<Value> ir_values =
@@ -81,6 +82,7 @@ Operation* CreateOperation(const OpCall& op_call,
         op_call.outputs()[0]->name(),
         std::make_shared<IrValue>(transpose_op->result(0)));
     return transpose_op;
+
   } else if (op_call.name() == "pd.cast") {
     const auto& inputs = op_call.inputs();
     std::vector<Value> ir_values =
@@ -91,6 +93,18 @@ Operation* CreateOperation(const OpCall& op_call,
     res_match_ctx->BindIrValue(op_call.outputs()[0]->name(),
                                std::make_shared<IrValue>(cast_op->result(0)));
     return cast_op;
+
+  } else if (op_call.name() == "pd.full") {
+    const auto& inputs = op_call.inputs();
+    std::vector<Value> ir_values = 
+        GetIrValuesByDrrTensors(inputs, *res_match_ctx);
+    Operation* full_op = rewriter.Build<paddle::dialect::FullOp>(
+        CreateAttributeMap(op_call, src_match_ctx)
+    );
+    res_match_ctx->BindIrValue(
+      op_call.outputs()[0]->name(),
+      std::make_shared<IrValue>(full_op->result(0)));
+    return full_op;
   }
 
   LOG(ERROR) << "Unknown op " << op_call.name();

--- a/paddle/fluid/ir/drr/ir_operation_creator.cc
+++ b/paddle/fluid/ir/drr/ir_operation_creator.cc
@@ -70,7 +70,7 @@ Operation* CreateOperation(const OpCall& op_call,
         op_call.outputs()[1]->name(),
         std::make_shared<IrValue>(reshape_op->result(1)));
     return reshape_op;
-    
+
   } else if (op_call.name() == "pd.transpose") {
     const auto& inputs = op_call.inputs();
     std::vector<Value> ir_values =
@@ -96,19 +96,16 @@ Operation* CreateOperation(const OpCall& op_call,
 
   } else if (op_call.name() == "pd.full") {
     const auto& inputs = op_call.inputs();
-    std::vector<Value> ir_values = 
+    std::vector<Value> ir_values =
         GetIrValuesByDrrTensors(inputs, *res_match_ctx);
     Operation* full_op = rewriter.Build<paddle::dialect::FullOp>(
-        CreateAttributeMap(op_call, src_match_ctx)
-    );
-    res_match_ctx->BindIrValue(
-      op_call.outputs()[0]->name(),
-      std::make_shared<IrValue>(full_op->result(0)));
+        CreateAttributeMap(op_call, src_match_ctx));
+    res_match_ctx->BindIrValue(op_call.outputs()[0]->name(),
+                               std::make_shared<IrValue>(full_op->result(0)));
     return full_op;
   }
 
-  LOG(ERROR) << "Unknown op " << op_call.name();
-  return nullptr;
+  PADDLE_THROW("Unknown op :" + op_call.name());
 }
 
 }  // namespace drr

--- a/paddle/fluid/ir/drr/match_context_impl.h
+++ b/paddle/fluid/ir/drr/match_context_impl.h
@@ -42,6 +42,7 @@ PD_SPECIALIZE_CppTypeToIrAttribute(int64_t, Int64Attribute);
 PD_SPECIALIZE_CppTypeToIrAttribute(float, FloatAttribute);
 PD_SPECIALIZE_CppTypeToIrAttribute(phi::DataType,
                                    paddle::dialect::DataTypeAttribute);
+PD_SPECIALIZE_CppTypeToIrAttribute(phi::Place, paddle::dialect::PlaceAttribute);
 
 template <typename T>
 struct IrAttrTypeCast {
@@ -59,6 +60,28 @@ struct IrAttrTypeCast<std::vector<int32_t>> {
       result.push_back(array_attr.at(i).dyn_cast<ir::Int32Attribute>().data());
     }
     return result;
+  }
+};
+
+template <>
+struct IrAttrTypeCast<std::vector<int64_t>>{
+  static std::vector<int64_t> To(const ir::Attribute& attr){
+    std::vector<int64_t> result;
+    auto array_attr = attr.dyn_cast<ir::ArrayAttribute>();   
+
+    if (array_attr) {
+      for(size_t i = 0; i < array_attr.size(); i++){
+        result.push_back(array_attr.at(i).dyn_cast<ir::Int64Attribute>().data());
+      }
+      return result;
+    } 
+
+    else if (attr.dyn_cast<paddle::dialect::IntArrayAttribute>()) {
+      result = attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
+      return result;
+    }
+    LOG(ERROR) << "Dynamic cast failed for IR attribute vector<int64_t>";
+    IR_THROW();
   }
 };
 

--- a/paddle/fluid/ir/drr/match_context_impl.h
+++ b/paddle/fluid/ir/drr/match_context_impl.h
@@ -79,7 +79,7 @@ struct IrAttrTypeCast<std::vector<int64_t>> {
           attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
       return result;
     }
-    IR_THROW("Dynamic cast failed for IR attribute vector<int64_t>");
+    PADDLE_THROW("Dynamic cast failed for IR attribute vector<int64_t>");
   }
 };
 

--- a/paddle/fluid/ir/drr/match_context_impl.h
+++ b/paddle/fluid/ir/drr/match_context_impl.h
@@ -64,24 +64,22 @@ struct IrAttrTypeCast<std::vector<int32_t>> {
 };
 
 template <>
-struct IrAttrTypeCast<std::vector<int64_t>>{
-  static std::vector<int64_t> To(const ir::Attribute& attr){
+struct IrAttrTypeCast<std::vector<int64_t>> {
+  static std::vector<int64_t> To(const ir::Attribute& attr) {
     std::vector<int64_t> result;
-    auto array_attr = attr.dyn_cast<ir::ArrayAttribute>();   
-
-    if (array_attr) {
-      for(size_t i = 0; i < array_attr.size(); i++){
-        result.push_back(array_attr.at(i).dyn_cast<ir::Int64Attribute>().data());
+    if (attr.dyn_cast<ir::ArrayAttribute>()) {
+      auto array_attr = attr.dyn_cast<ir::ArrayAttribute>();
+      for (size_t i = 0; i < array_attr.size(); i++) {
+        result.push_back(
+            array_attr.at(i).dyn_cast<ir::Int64Attribute>().data());
       }
       return result;
-    } 
-
-    else if (attr.dyn_cast<paddle::dialect::IntArrayAttribute>()) {
-      result = attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
+    } else if (attr.dyn_cast<paddle::dialect::IntArrayAttribute>()) {
+      result =
+          attr.dyn_cast<paddle::dialect::IntArrayAttribute>().data().GetData();
       return result;
     }
-    LOG(ERROR) << "Dynamic cast failed for IR attribute vector<int64_t>";
-    IR_THROW();
+    IR_THROW("Dynamic cast failed for IR attribute vector<int64_t>");
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
1. Add fusion testing code for full and expand
2. Add support for pd.full in ir op creator
3. Add support for Place attribute
4. Add vector<int64 in IrAttrTypeCast_ t> Property support for types