### PR TITLE
Fix bug of delete op in drr

### DIFF
--- a/paddle/fluid/pir/drr/drr_rewrite_pattern.h
+++ b/paddle/fluid/pir/drr/drr_rewrite_pattern.h
@@ -393,6 +393,12 @@ class DrrRewritePattern : public pir::RewritePattern {
                   topo_order_ops.end(),
                   [&forward_deleted_ops,
                    &forward_visited_tensor_set](const OpCall* op_call) {
+                    if (op_call->inputs().empty()) {
+                      forward_deleted_ops.insert(op_call);
+                      for (const auto* output : op_call->outputs()) {
+                        forward_visited_tensor_set.insert(output->name());
+                      }
+                    }
                     for (const auto* input : op_call->inputs()) {
                       if (forward_visited_tensor_set.count(input->name())) {
                         forward_deleted_ops.insert(op_call);
@@ -423,6 +429,8 @@ class DrrRewritePattern : public pir::RewritePattern {
                   all_comsumer_deleted = false;
                 }
               }
+            } else if (output->consumers().empty()) {
+              continue;
             } else {
               all_comsumer_deleted = false;
             }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复DRR在删除source pattern中的Op时部分场景下Op未能删除的bug。