### PR TITLE
[DRR] Refactor logic of insert point for creating new operation in drr

### DIFF
--- a/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
+++ b/test/cpp/pir/pattern_rewrite/drr_fuse_linear_test.cc
@@ -23,7 +23,6 @@
 #include "paddle/pir/pass/pass.h"
 #include "paddle/pir/pass/pass_manager.h"
 #include "paddle/pir/pattern_rewrite/pattern_rewrite_driver.h"
-#include "paddle/pir/transforms/reorder_block_ops_pass.h"
 
 class FusedLinearPattern : public pir::drr::DrrPatternBase<FusedLinearPattern> {
  public:
@@ -349,7 +348,6 @@ TEST(DrrTest, FusedLinear) {
 
   pir::PassManager pm(ctx);
   pm.AddPass(std::make_unique<FusedLinearPass>());
-  pm.AddPass(pir::CreateReorderBlockOpsPass());
   // pm.AddPass(pir::CreateDeadCodeEliminationPass());
   // pm.EnablePassTiming();
   pm.EnableIRPrinting();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
优化重构DRR中创建新Operation时InsertPoint的设置逻辑，重构后可将ResultPattern中创建的新Op根据输入Op的拓扑序准确插入到block中的对应位置。