### PR TITLE
Make count variable as thread_local in Op class

### DIFF
--- a/paddle/fluid/pir/drr/api/drr_pattern_context.cc
+++ b/paddle/fluid/pir/drr/api/drr_pattern_context.cc
@@ -132,7 +132,7 @@ Tensor& Op::operator()() const {
   return out;
 }
 
-int64_t Op::count = 0;
+thread_local int64_t Op::count = 0;
 const char* Op::prefix = "@drr_temp@_";
 
 const char Tensor::NONE_TENSOR_NAME[] = "__@none_tensor@__";

--- a/paddle/fluid/pir/drr/api/drr_pattern_context.h
+++ b/paddle/fluid/pir/drr/api/drr_pattern_context.h
@@ -177,7 +177,7 @@ class Op {
     return attributes_;
   }
 
-  static int64_t count;
+  thread_local static int64_t count;
 
   std::string op_type_name_;
   std::unordered_map<std::string, Attribute> attributes_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
将Op类中的count静态成员变量设置为thread_local类型，避免多线程场景下的读写冲突问题。