### PR TITLE
add qkv_transpose_spli op with GPU kernel

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -2880,3 +2880,12 @@
   optional : gt_score
   intermediate : objectness_mask, gt_match_mask
   backward : yolo_loss_grad
+
+- op : qkv_transpose_split
+  args : (Tensor qkv, Tensor padding_offset, Tensor seq_lens, Tensor input_ids, int num_head, int head_size)
+  output : Tensor (q_out), Tensor(k_out), Tensor(v_out)
+  infer_meta :
+    func : QkvTransposeSplitInferMeta
+  kernel :
+    func : qkv_transpose_split
+    data_type : qkv

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -4440,5 +4440,25 @@ void FullWithTensorInferMeta(const MetaTensor& shape,
   out->set_dtype(dtype);
 }
 
+void QkvTransposeSplitInferMeta(const MetaTensor& qkv,
+                            const MetaTensor& padding_offset,
+                            const MetaTensor& seq_lens,
+                            const MetaTensor& input_ids,
+                            int num_head,
+                            int head_size,
+                            MetaTensor* q_out,
+                            MetaTensor* k_out,
+                            MetaTensor* v_out) {
+  int bsz = static_cast<int>(seq_lens.dims()[0]);
+  int fused_hidden_size = static_cast<int>(qkv.dims()[1]);
+  int kv_num_head = (fused_hidden_size - num_head * head_size) / head_size / 2;
+  q_out->set_dims(phi::make_ddim({bsz, num_head, -1, head_size}));
+  q_out->set_dtype(qkv.dtype());
+  k_out->set_dims(phi::make_ddim({bsz, kv_num_head, -1, head_size}));
+  k_out->set_dtype(qkv.dtype());
+  v_out->set_dims(phi::make_ddim({bsz, kv_num_head, -1, head_size}));
+  v_out->set_dtype(qkv.dtype());
+}
+
 }  // namespace phi
 PD_REGISTER_INFER_META_FN(batch_norm_infer, phi::BatchNormInferInferMeta);

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -873,4 +873,14 @@ void FullWithTensorInferMeta(const MetaTensor& shape,
                              DataType dtype,
                              MetaTensor* out);
 
+void QkvTransposeSplitInferMeta(const MetaTensor& qkv,
+                            const MetaTensor& padding_offset,
+                            const MetaTensor& seq_lens,
+                            const MetaTensor& input_ids,
+                            int num_head,
+                            int head_size,
+                            MetaTensor* q_out,
+                            MetaTensor* k_out,
+                            MetaTensor* v_out);
+
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/qkv_transpose_split_kernel.cu
+++ b/paddle/phi/kernels/gpu/qkv_transpose_split_kernel.cu
@@ -1,0 +1,175 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/qkv_transpose_split_kernel.h"
+
+#include <cuda_fp16.h>
+#include <curand_kernel.h>
+
+#include "cub/cub.cuh"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_device_function.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/primitive/functor_primitives.h"
+#include "paddle/phi/common/datatype_traits.h"
+#include "paddle/phi/kernels/funcs/aligned_vector.h"
+namespace {
+constexpr int VEC_16B = 16;
+
+template <typename T, int VecSize>
+__global__ void fusedQKV_transpose_split_kernel(
+    T *q_buf,
+    T *k_buf,
+    T *v_buf,
+    const T *qkv,
+    const int *padding_offset,
+    const int *seq_lens,
+    const int32_t elem_cnt,
+    const int batch_size,
+    const int max_len_this_time,
+    const int seq_len,
+    const int token_num,
+    const int head_num,
+    const int kv_head_num,
+    const int size_per_head) {
+  const int32_t hidden_size = head_num * size_per_head;
+  const int32_t fused_hidden_size = hidden_size + kv_head_num * size_per_head + kv_head_num * size_per_head;
+
+  int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x;
+  using LoadT = phi::AlignedVector<T, VecSize>;
+  LoadT src_vec;
+  LoadT bias_vec;
+  for (int32_t linear_index = global_thread_idx * VecSize,
+               step = gridDim.x * blockDim.x * VecSize;
+       linear_index < elem_cnt;
+       linear_index += step) {
+    phi::Load<T, VecSize>(&qkv[linear_index], &src_vec);
+    int32_t bias_idx = linear_index % fused_hidden_size;
+    const int32_t token_idx = linear_index / fused_hidden_size;
+    const int32_t ori_token_idx =
+        token_idx + (padding_offset == nullptr ? 0 : padding_offset[token_idx]);
+    const int32_t target_batch_id = ori_token_idx / seq_len;
+    if (seq_lens[target_batch_id] == 0) continue;
+    const int32_t seq_id = ori_token_idx % seq_len;
+
+    const int32_t qkv_id = bias_idx < hidden_size ? 0 : (bias_idx -  hidden_size) / ( kv_head_num * size_per_head) + 1;
+    const int32_t head_id = qkv_id == 0 ? bias_idx / size_per_head : (bias_idx -  hidden_size) / size_per_head % kv_head_num;
+    const int32_t size_id = bias_idx % size_per_head;
+
+    if (qkv_id == 0) {
+      phi::Store<T, VecSize>(
+          src_vec,
+          &q_buf[target_batch_id * head_num * max_len_this_time * size_per_head +
+                 head_id * max_len_this_time * size_per_head + seq_id * size_per_head +
+                 size_id]);
+    } else if (qkv_id == 1) {
+      phi::Store<T, VecSize>(
+          src_vec,
+          &k_buf[target_batch_id * kv_head_num * max_len_this_time * size_per_head +
+                 head_id * max_len_this_time * size_per_head + seq_id * size_per_head +
+                 size_id]);
+    } else {
+      phi::Store<T, VecSize>(
+          src_vec,
+          &v_buf[target_batch_id * kv_head_num * max_len_this_time * size_per_head +
+                 head_id * max_len_this_time * size_per_head + seq_id * size_per_head +
+                 size_id]);
+    }
+  }
+}
+
+} // namespace
+
+namespace phi {
+
+template <typename T, typename Context>
+void QkvTransposeSplitKernel(const Context& dev_ctx,
+                        const DenseTensor& qkv,
+                        const DenseTensor& padding_offset,
+                        const DenseTensor& seq_lens,
+                        const DenseTensor& input_ids,
+                        int num_head,
+                        int head_size,
+                        DenseTensor* q_out,
+                        DenseTensor* k_out,
+                        DenseTensor* v_out) {
+    using DataType_ = typename PDDataTypeTraits<T>::DataType;
+    auto cu_stream = dev_ctx.stream();
+
+    const auto* qkv_input = &qkv;
+    const auto& qkv_dims = qkv_input->dims();
+
+    const auto* seq_input = &seq_lens;
+    const auto& seq_dims = seq_input->dims();
+
+    const int token_num = qkv_dims[0];
+    const int bsz = seq_lens.dims()[0];
+    const int max_seq_len = input_ids.dims()[1];
+
+    int64_t fused_hidden_size = qkv_dims[1];
+    int kv_num_head = (fused_hidden_size - num_head * head_size) / head_size / 2;
+
+    q_out->Resize({bsz, num_head, max_seq_len, head_size});
+    k_out->Resize({bsz, kv_num_head, max_seq_len, head_size});
+    v_out->Resize({bsz, kv_num_head, max_seq_len, head_size});
+
+
+    T* q_out_ptr = dev_ctx.template Alloc<T>(q_out);
+    T* k_out_ptr = dev_ctx.template Alloc<T>(k_out);
+    T* v_out_ptr = dev_ctx.template Alloc<T>(v_out);
+
+    if (!k_out_ptr || !k_out_ptr || !v_out_ptr) return;
+
+    funcs::SetConstant<Context, T> set_zero;
+    set_zero(dev_ctx, q_out, static_cast<T>(0));
+    set_zero(dev_ctx, k_out, static_cast<T>(0));
+    set_zero(dev_ctx, v_out, static_cast<T>(0));
+
+    constexpr int PackSize = VEC_16B / sizeof(DataType_);
+    const int elem_cnt = qkv_dims[0] * qkv_dims[1];
+    const int pack_num = elem_cnt / PackSize;
+    const int blocksize = 128;
+    const int grid_size = (pack_num + blocksize - 1) / blocksize;
+
+    fusedQKV_transpose_split_kernel<T, PackSize>
+      <<<grid_size, blocksize, 0, cu_stream>>>(
+        q_out_ptr,
+        k_out_ptr,
+        v_out_ptr,
+        qkv.data<T>(),
+        padding_offset.data<int>(),
+        seq_lens.data<int>(),
+        elem_cnt,
+        bsz,
+        max_seq_len,
+        max_seq_len,
+        token_num,
+        num_head,
+        kv_num_head,
+        head_size);
+    return;
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(qkv_transpose_split,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::QkvTransposeSplitKernel,
+                   float,
+                   double,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/qkv_transpose_split_kernel.h
+++ b/paddle/phi/kernels/qkv_transpose_split_kernel.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void QkvTransposeSplitKernel(const Context& dev_ctx,
+                        const DenseTensor& qkv,
+                        const DenseTensor& padding_offset,
+                        const DenseTensor& seq_lens,
+                        const DenseTensor& input_ids,
+                        int num_head,
+                        int head_size,
+                        DenseTensor* q_out,
+                        DenseTensor* k_out,
+                        DenseTensor* v_out);
+
+}  // namespace phi

--- a/python/paddle/incubate/nn/functional/__init__.py
+++ b/python/paddle/incubate/nn/functional/__init__.py
@@ -32,6 +32,7 @@ from .fused_rms_norm import fused_rms_norm
 from .fused_layer_norm import fused_layer_norm
 from .masked_multihead_attention import masked_multihead_attention
 from .write_cache_kv import write_cache_kv
+from .qkv_transpose_split import qkv_transpose_split
 
 __all__ = [
     'fused_multi_head_attention',

--- a/python/paddle/incubate/nn/functional/qkv_transpose_split.py
+++ b/python/paddle/incubate/nn/functional/qkv_transpose_split.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from paddle import _C_ops
+from paddle.framework import LayerHelper, in_dynamic_mode
+
+
+def qkv_transpose_split(
+    qkv,
+    padding_offset,
+    seq_lens,
+    input_ids,
+    num_head,
+    head_size
+):
+    r"""
+    Apply QkvTransposeSplitKernel kernel.
+    Args:
+        qkv (Tensor): the input qkv Tensor.
+        padding_offset (Tensor): the padding_offset v Tensor.
+        seq_lens (Tensor): the input seq_lens Tensor.
+        input_ids (Tensor): the input input_ids Tensor.
+        num_head (int): The num_head, Default 1.
+    Returns:
+        Tensor: the output Tensor.
+    Examples:
+        .. code-block:: python
+            >>> # doctest: +REQUIRES(env:GPU)
+            >>> import paddle
+            >>> paddle.device.set_device('gpu')
+    """
+    if in_dynamic_mode():
+        return _C_ops.qkv_transpose_split(
+            qkv,
+            padding_offset,
+            seq_lens,
+            input_ids,
+            num_head,
+            head_size,
+        )
+
+    helper = LayerHelper('qkv_transpose_split', **locals())
+
+    inputs = {
+        'qkv': qkv,
+        'padding_offset': padding_offset,
+        'seq_lens': seq_lens,
+        'input_ids': input_ids,
+    }
+
+    q_out = helper.create_variable_for_type_inference(
+        dtype=qkv.dtype
+    )
+    k_out = helper.create_variable_for_type_inference(
+        dtype=qkv.dtype
+    )
+    v_out = helper.create_variable_for_type_inference(
+        dtype=qkv.dtype
+    )
+
+    outputs_dict = {
+        'q_out': q_out,
+        'k_out': k_out,
+        'v_out': v_out,
+        }
+
+    helper.append_op(
+        type='qkv_transpose_split',
+        inputs=inputs,
+        outputs=outputs_dict,
+        attrs={
+            'num_head': num_head,
+            'head_size': head_size,
+        },
+    )
+
+    return (q_out, k_out, v_out)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Description
<!-- Describe what you’ve done -->
Pcard-71500
add qkv_transpose_spli op with GPU kernel